### PR TITLE
Fix DiamondBank-OG Kotlin API import and provider wiring

### DIFF
--- a/src/main/kotlin/plugin/KotlinTemplateOG.kt
+++ b/src/main/kotlin/plugin/KotlinTemplateOG.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
-import net.trueog.diamondbankog.DiamondBankAPIKotlin
+import net.trueog.diamondbankog.api.DiamondBankAPIKotlin
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
@@ -32,7 +32,7 @@ class KotlinTemplateOG : JavaPlugin() {
             Bukkit.getPluginManager().disablePlugin(this)
             return
         }
-        val diamondBankAPI = diamondBankAPIProvider.getProvider()
+        diamondBankAPI = diamondBankAPIProvider.provider
 
         this.server.pluginManager.registerEvents(Listeners(), this)
     }


### PR DESCRIPTION
### Motivation
- Resolve compilation/runtime errors by using the correct DiamondBank-OG Kotlin API type and ensure the plugin-level API instance is initialized per the DiamondBank-OG service registration API.

### Description
- Updated the import to `net.trueog.diamondbankog.api.DiamondBankAPIKotlin` in `src/main/kotlin/plugin/KotlinTemplateOG.kt` to match the library package layout.
- Wired the resolved service to the companion field by assigning `diamondBankAPI = diamondBankAPIProvider.provider` instead of creating a shadowing local `val`.

### Testing
- Ran a full build with `./gradlew clean build eclipse --warning-mode all`, which previously failed with unresolved references and checkstyle issues before this change.
- Re-ran compilation for the modified module with `./gradlew :compileKotlin --warning-mode all`, which failed in this environment due to a local tooling/Gradle error (`25.0.1`), so automated compilation could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b256fc18832f96ce695c39824889)